### PR TITLE
Fix GitHub workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.24.1'
         cache: true
 
     - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,16 +19,17 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.24.1'
         cache: true
 
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: '1.24'
+        go-version-input: '1.24.1'
         check-latest: true
 
+    - name: Install gosec
+      run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+
     - name: Run gosec
-      uses: securego/gosec@master
-      with:
-        args: -exclude-dir=.github -exclude-dir=examples ./...
+      run: gosec -exclude-dir=.github -exclude-dir=examples ./...

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: all build test clean lint install-tools tidy bench cover vet fmt check
+.PHONY: all build test clean lint install-tools tidy bench cover vet fmt check gosec
 
 GOPATH := $(shell go env GOPATH)
 BIN_DIR := $(GOPATH)/bin
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
+GOSEC := $(BIN_DIR)/gosec
 
 all: test build
 
@@ -23,11 +24,19 @@ $(GOLANGCI_LINT):
 	@echo "Installing golangci-lint..."
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
+$(GOSEC):
+	@echo "Installing gosec..."
+	@go install github.com/securego/gosec/v2/cmd/gosec@latest
+
 lint: $(GOLANGCI_LINT)
 	@echo "Running linter..."
 	@$(GOLANGCI_LINT) run --timeout=5m
 
-install-tools: $(GOLANGCI_LINT)
+gosec: $(GOSEC)
+	@echo "Running security scanner..."
+	@$(GOSEC) -exclude-dir=.github -exclude-dir=examples ./...
+
+install-tools: $(GOLANGCI_LINT) $(GOSEC)
 	@echo "All tools installed"
 
 tidy:
@@ -51,5 +60,5 @@ fmt:
 	@echo "Running go fmt..."
 	@go fmt ./...
 
-check: fmt vet lint test
+check: fmt vet lint gosec test
 	@echo "All checks passed!"

--- a/model/openai.go
+++ b/model/openai.go
@@ -258,8 +258,7 @@ func (s *OpenAIStream) Recv() (*StreamChunk, error) {
 }
 
 func (s *OpenAIStream) Close() error {
-	s.stream.Close()
-	return nil
+	return s.stream.Close()
 }
 
 func mapToOpenAITool(toolMap map[string]any) (openai.Tool, error) {

--- a/tracing/exporter.go
+++ b/tracing/exporter.go
@@ -102,7 +102,7 @@ func NewOpenAIExporter(options OpenAIExporterOptions) (*OpenAIExporter, error) {
 
 	// Create backup directory if specified
 	if options.BackupDir != "" {
-		if err := os.MkdirAll(options.BackupDir, 0755); err != nil {
+		if err := os.MkdirAll(options.BackupDir, 0750); err != nil {
 			return nil, fmt.Errorf("failed to create backup directory: %w", err)
 		}
 	}
@@ -209,7 +209,7 @@ func (e *OpenAIExporter) saveToBackup(spans []*StandardSpan) error {
 	}
 
 	// Write to file
-	err = os.WriteFile(filepath, jsonData, 0644)
+	err = os.WriteFile(filepath, jsonData, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write backup file: %w", err)
 	}

--- a/tracing/processor.go
+++ b/tracing/processor.go
@@ -221,7 +221,7 @@ func (p *BatchSpanProcessor) saveSpanToBackup(span *StandardSpan) error {
 	}
 
 	// Ensure the backup directory exists
-	if err := os.MkdirAll(p.options.BackupDir, 0755); err != nil {
+	if err := os.MkdirAll(p.options.BackupDir, 0750); err != nil {
 		return fmt.Errorf("failed to create backup directory: %w", err)
 	}
 
@@ -237,7 +237,7 @@ func (p *BatchSpanProcessor) saveSpanToBackup(span *StandardSpan) error {
 	}
 
 	// Write to file
-	if err := os.WriteFile(filepath, spanJSON, 0644); err != nil {
+	if err := os.WriteFile(filepath, spanJSON, 0600); err != nil {
 		return fmt.Errorf("failed to write backup file: %w", err)
 	}
 
@@ -291,18 +291,17 @@ func (p *BatchSpanProcessor) export(batch []*StandardSpan) {
 			}
 
 			// Ensure the backup directory exists
-			if err := os.MkdirAll(p.options.BackupDir, 0755); err != nil {
+			if err := os.MkdirAll(p.options.BackupDir, 0750); err != nil {
 				logger.Error("Failed to create backup directory: %v", err)
 				return
 			}
 
 			// Write to file
-			if err := os.WriteFile(batchBackupFile, jsonData, 0644); err != nil {
+			if err := os.WriteFile(batchBackupFile, jsonData, 0600); err != nil {
 				logger.Error("Failed to write batch backup file: %v", err)
-				return
+			} else {
+				logger.Info("Saved batch to backup file: %s", batchBackupFile)
 			}
-
-			logger.Info("Saved batch of %d spans to backup file: %s", len(batch), batchBackupFile)
 		}
 	} else {
 		logger.Info("Successfully exported %d spans", len(batch))


### PR DESCRIPTION
## やったこと
- [Security Scanの`Run gosec`でGoのバージョンが`go.mod`と合わないエラー](https://github.com/ryichk/ai-agents-sdk-go/actions/runs/13885471820/job/38849605947?pr=1)を修正
- [Security Issue](https://github.com/ryichk/ai-agents-sdk-go/actions/runs/13885576631/job/38849853193?pr=1)を修正
  - ディレクトリパーミッションの修正:
    os.MkdirAll()関数で作成されるディレクトリのパーミッションを0755から0750に変更
  - ファイルパーミッションの修正:
    os.WriteFile()関数で作成されるファイルのパーミッションを0644から0600に変更
  - エラー処理の追加:
    model/openai.goのOpenAIStream.Close()メソッドで、s.stream.Close()の戻り値（エラー）を適切に処理するように修正
- ローカルでセキュリティスキャンを実行できるように`make gosec`コマンドを追加
- 並列実行した際に`tracing_test.go`のテストでrace conditionが発生する問題を修正
  - 複数のgoroutineが同時に`MockExporter.ExportedSpans`スライスを読み書きしていたことが問題だった。
  - `MockExporter`にmutexを追加し、スライスへのアクセスを同期化することで解決した。